### PR TITLE
common Makefile, cleanups

### DIFF
--- a/01_bareminimum/Makefile
+++ b/01_bareminimum/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,19 +24,23 @@
 #
 #
 
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+include ../Makefile-common
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o -T link.ld -o $@
 
-kernel8.img: start.o
-	aarch64-elf-ld -nostdlib -nostartfiles start.o -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -d in_asm
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -d in_asm -display none
+

--- a/02_multicorec/Makefile
+++ b/02_multicorec/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -d in_asm
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -d in_asm -display none
+

--- a/03_uart1/Makefile
+++ b/03_uart1/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial null -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial null -serial stdio -display none
+

--- a/04_mailboxes/Makefile
+++ b/04_mailboxes/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial null -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial null -serial stdio -display none
+

--- a/04_mailboxes/mbox.c
+++ b/04_mailboxes/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/05_uart0/mbox.c
+++ b/05_uart0/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/06_random/Makefile
+++ b/06_random/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial stdio -display none
+

--- a/06_random/mbox.c
+++ b/06_random/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/07_delays/Makefile
+++ b/07_delays/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial stdio -display none
+

--- a/07_delays/mbox.c
+++ b/07_delays/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/08_power/Makefile
+++ b/08_power/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial stdio -display none
+

--- a/08_power/mbox.c
+++ b/08_power/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/09_framebuffer/Makefile
+++ b/09_framebuffer/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial stdio
+

--- a/09_framebuffer/mbox.c
+++ b/09_framebuffer/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/0A_pcscreenfont/Makefile
+++ b/0A_pcscreenfont/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,27 +24,29 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
-
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
 font.o: font.psf
-	aarch64-elf-ld -r -b binary -o font.o font.psf
+	$(LD) -r -b binary -o $@ $<
 
-kernel8.img: start.o font.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o font.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.elf: start.o font.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o font.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial stdio
+

--- a/0A_pcscreenfont/mbox.c
+++ b/0A_pcscreenfont/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/0B_readsector/Makefile
+++ b/0B_readsector/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio -display none
+

--- a/0B_readsector/mbox.c
+++ b/0B_readsector/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/0C_directory/Makefile
+++ b/0C_directory/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio -display none
+

--- a/0C_directory/mbox.c
+++ b/0C_directory/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/0D_readfile/Makefile
+++ b/0D_readfile/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio -display none
+

--- a/0D_readfile/mbox.c
+++ b/0D_readfile/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/0E_initrd/Makefile
+++ b/0E_initrd/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,33 +24,35 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run cpio tar
 
 all: clean kernel8.img
-
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
-
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
 
 tar:
 	tar -cf ramdisk *.md *.c *.h
 
 cpio:
-	ls *.md *.c *.h | cpio -H hpodc -o >ramdisk
+	ls *.md *.c *.h | cpio -H hpodc -o > ramdisk
 
 rd.o: ramdisk
-	aarch64-elf-ld -r -b binary -o rd.o ramdisk
+	$(LD) -r -b binary -o $@ $<
 
-kernel8.img: start.o rd.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o rd.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.elf: start.o rd.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o rd.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o rd.o $(OBJS) -T link.ld -o $@
+
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial stdio -display none
+

--- a/0E_initrd/mbox.c
+++ b/0E_initrd/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/0F_executionlevel/Makefile
+++ b/0F_executionlevel/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial stdio -display none
+

--- a/0F_executionlevel/mbox.c
+++ b/0F_executionlevel/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/10_virtualmemory/Makefile
+++ b/10_virtualmemory/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial stdio -display none
+

--- a/10_virtualmemory/mbox.c
+++ b/10_virtualmemory/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/10_virtualmemory/mmu.c
+++ b/10_virtualmemory/mmu.c
@@ -49,8 +49,8 @@
 #define TTBR_ENABLE 1
 
 // get addresses from linker
-extern volatile unsigned char _data;
-extern volatile unsigned char _end;
+extern unsigned char _data;
+extern unsigned char _end;
 
 /**
  * Set up page translation tables and enable virtual memory

--- a/11_exceptions/Makefile
+++ b/11_exceptions/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial stdio -display none
+

--- a/11_exceptions/mbox.c
+++ b/11_exceptions/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/11_exceptions/mmu.c
+++ b/11_exceptions/mmu.c
@@ -49,8 +49,8 @@
 #define TTBR_ENABLE 1
 
 // get addresses from linker
-extern volatile unsigned char _data;
-extern volatile unsigned char _end;
+extern unsigned char _data;
+extern unsigned char _end;
 
 /**
  * Set up page translation tables and enable virtual memory

--- a/12_printf/Makefile
+++ b/12_printf/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial stdio -display none
+

--- a/12_printf/mbox.c
+++ b/12_printf/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/13_debugger/Makefile
+++ b/13_debugger/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial stdio -display none
+

--- a/13_debugger/mbox.c
+++ b/13_debugger/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[36];
+unsigned int  __attribute__((aligned(16))) mbox[36];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/14_raspbootin64/Makefile
+++ b/14_raspbootin64/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 bzt (bztsrc@github)
+# Copyright (C) 2018 Florian La Roche (Florian.LaRoche@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -23,24 +24,26 @@
 #
 #
 
+include ../Makefile-common
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+
+.PHONY: all clean run
 
 all: clean kernel8.img
 
-start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+kernel8.elf: start.o $(OBJS) link.ld
+	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
 
-%.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
-
-kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+kernel8.img: kernel8.elf
+	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
+	$(OBJCOPY) -O binary $< $@
 
 clean:
-	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
+	rm -f kernel8.elf kernel8.map kernel8.sym *.o
 
-run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+run: all
+	$(QEMU) -M raspi3 -kernel kernel8.img -serial stdio -display none
+

--- a/14_raspbootin64/mbox.c
+++ b/14_raspbootin64/mbox.c
@@ -26,7 +26,7 @@
 #include "gpio.h"
 
 /* mailbox message buffer */
-volatile unsigned int  __attribute__((aligned(16))) mbox[8];
+unsigned int  __attribute__((aligned(16))) mbox[8];
 
 #define VIDEOCORE_MBOX  (MMIO_BASE+0x0000B880)
 #define MBOX_READ       ((volatile unsigned int*)(VIDEOCORE_MBOX+0x0))

--- a/Makefile-common
+++ b/Makefile-common
@@ -24,26 +24,23 @@
 #
 #
 
-include ../Makefile-common
 
-SRCS = $(wildcard *.c)
-OBJS = $(SRCS:.c=.o)
+CROSSCOMPILE ?= aarch64-elf-
+#CCACHE = ccache
+CC = $(CCACHE) $(CROSSCOMPILE)gcc
+#CC = $(CCACHE) clang -target aarch64-unknown-eabihf -march=armv8-a+nosimd+nofp -mgeneral-regs-only
+LD = $(CROSSCOMPILE)ld
+OBJCOPY = $(CROSSCOMPILE)objcopy
+OBJDUMP = $(CROSSCOMPILE)objdump
+QEMU = qemu-system-aarch64
 
-.PHONY: all clean run
+CFLAGS = -Wall -Wno-shift-negative-value -O2 -ffreestanding -nostdinc -I include
+LDFLAGS = -nostdlib -nostartfiles
 
-all: clean kernel8.img
 
-kernel8.elf: start.o $(OBJS) link.ld
-	$(LD) $(LDFLAGS) -Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
-	#$(CC) $(CFLAGS) $(LDFLAGS) -Wl,-Map=kernel8.map start.o $(OBJS) -T link.ld -o $@
+%.o: %.S
+	$(CC) $(CFLAGS) -c $< -o $@
 
-kernel8.img: kernel8.elf
-	$(OBJDUMP) -t $< | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' | sort > kernel8.sym
-	$(OBJCOPY) -O binary $< $@
-
-clean:
-	rm -f kernel8.elf kernel8.map kernel8.sym *.o
-
-run: all
-	$(QEMU) -M raspi3 -kernel kernel8.img -serial stdio -display none
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
 


### PR DESCRIPTION
change to clang as compiler with one line change in Makefile-common
allow to use "ccache" by enabling one line in Makefile-common
qemu: disable display if not used
remove "volatile" from some param declarations, this is not needed
