### PR TITLE
Use common config for all tutorial steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+*.elf
+0E_initrd/ramdisk

--- a/00_crosscompiler/README.md
+++ b/00_crosscompiler/README.md
@@ -12,6 +12,21 @@ you have to solve that on your own. As I've said in the introduction I assume yo
 
 **NOTE**: if you don't like gcc, thanks to @laroche, the tutorials are tested with Clang too.
 
+OS-provided cross compiler
+-------------------------
+
+Distribution derived from Debian (and possibly others) provide the `gcc-aarch64-linux-gnu` cross-compiler which works
+just fine with all the code in this tutorial. By default the tutorial makefiles use the cross-compiler built according
+to instructions below, but if you wish to save some time and use the one provide by your distribution you can compile
+all the samples with the distribution cross-compiler using the below command line:
+
+    make TOOLCHAIN_PREFIX=aarch64-linux-gnu
+
+Additionally, if your distribution has clang and you have it installed, you can build all the samples with it (you **still**
+need to install `gcc-aarch64-linux-gnu`) using the following command line:
+
+    make TOOLCHAIN_PREFIX=aarch64-linux-gnu USE_CLANG=1
+
 Build system
 ------------
 

--- a/01_bareminimum/Makefile
+++ b/01_bareminimum/Makefile
@@ -22,17 +22,16 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
-
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
+include ../Make.config
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 kernel8.img: start.o
-	aarch64-elf-ld -nostdlib -nostartfiles start.o -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/02_multicorec/Makefile
+++ b/02_multicorec/Makefile
@@ -23,21 +23,22 @@
 #
 #
 
+include ../Make.config
+
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/03_uart1/Makefile
+++ b/03_uart1/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/04_mailboxes/Makefile
+++ b/04_mailboxes/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/05_uart0/Makefile
+++ b/05_uart0/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/06_random/Makefile
+++ b/06_random/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/07_delays/Makefile
+++ b/07_delays/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/08_power/Makefile
+++ b/08_power/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/09_framebuffer/Makefile
+++ b/09_framebuffer/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/0A_pcscreenfont/Makefile
+++ b/0A_pcscreenfont/Makefile
@@ -22,25 +22,25 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 font.o: font.psf
-	aarch64-elf-ld -r -b binary -o font.o font.psf
+	$(LD_CROSS) -r -b binary -o font.o font.psf
 
 kernel8.img: start.o font.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o font.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o font.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/0B_readsector/Makefile
+++ b/0B_readsector/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/0C_directory/Makefile
+++ b/0C_directory/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/0D_readfile/Makefile
+++ b/0D_readfile/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
-SRCS = $(wildcard *.c)
+SRCS = $(wildcard *.c) ../compat/memcmp.c
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/0E_initrd/Makefile
+++ b/0E_initrd/Makefile
@@ -22,31 +22,31 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
-SRCS = $(wildcard *.c)
+SRCS = $(wildcard *.c) ../compat/memcmp.c
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 tar:
 	tar -cf ramdisk *.md *.c *.h
 
-cpio:
+ramdisk:
 	ls *.md *.c *.h | cpio -H hpodc -o >ramdisk
 
 rd.o: ramdisk
-	aarch64-elf-ld -r -b binary -o rd.o ramdisk
+	$(LD_CROSS) -r -b binary -o rd.o ramdisk
 
 kernel8.img: start.o rd.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o rd.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o rd.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/0F_executionlevel/Makefile
+++ b/0F_executionlevel/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/10_virtualmemory/Makefile
+++ b/10_virtualmemory/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/11_exceptions/Makefile
+++ b/11_exceptions/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/12_printf/Makefile
+++ b/12_printf/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/13_debugger/Makefile
+++ b/13_debugger/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/14_raspbootin64/Makefile
+++ b/14_raspbootin64/Makefile
@@ -22,22 +22,22 @@
 # DEALINGS IN THE SOFTWARE.
 #
 #
+include ../Make.config
 
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -Wall -O2 -ffreestanding -nostdinc -nostdlib -nostartfiles
 
 all: clean kernel8.img
 
 start.o: start.S
-	aarch64-elf-gcc $(CFLAGS) -c start.S -o start.o
+	$(CC_CROSS) $(CFLAGS) -c start.S -o start.o
 
 %.o: %.c
-	aarch64-elf-gcc $(CFLAGS) -c $< -o $@
+	$(CC_CROSS) $(CFLAGS) -c $< -o $@
 
 kernel8.img: start.o $(OBJS)
-	aarch64-elf-ld -nostdlib -nostartfiles start.o $(OBJS) -T link.ld -o kernel8.elf
-	aarch64-elf-objcopy -O binary kernel8.elf kernel8.img
+	$(LD_CROSS) $(LDFLAGS) start.o $(OBJS) -o kernel8.elf
+	$(OBJCOPY_CROSS) -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true

--- a/Make.config
+++ b/Make.config
@@ -1,0 +1,13 @@
+CFLAGS ?= -Wall -O2 -ffreestanding -nostdinc -nostdlib
+LDFLAGS ?= -nostdlib -nostartfiles -T link.ld
+TOOLCHAIN_PREFIX ?= aarch64-elf
+
+ifeq ($(USE_CLANG),)
+CFLAGS += -nostartfiles
+CC_CROSS ?= $(TOOLCHAIN_PREFIX)-gcc
+else
+CC_CROSS ?= clang -target aarch64-linux
+endif
+
+LD_CROSS ?= $(TOOLCHAIN_PREFIX)-ld$
+OBJCOPY_CROSS ?= $(TOOLCHAIN_PREFIX)-objcopy$

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+SUBDIRS = \
+	01_bareminimum    \
+	02_multicorec     \
+	03_uart1          \
+	04_mailboxes      \
+	05_uart0          \
+	06_random         \
+	07_delays         \
+	08_power          \
+	09_framebuffer    \
+	0A_pcscreenfont   \
+	0B_readsector     \
+	0C_directory      \
+	0D_readfile       \
+	0E_initrd         \
+	0F_executionlevel \
+	10_virtualmemory  \
+	11_exceptions     \
+	12_printf         \
+	13_debugger       \
+	14_raspbootin64
+
+.PHONY: subdirs $(SUBDIRS)
+
+subdirs: $(SUBDIRS)
+
+$(SUBDIRS):
+	$(MAKE) -C $@
+
+all: subdirs

--- a/compat/memcmp.c
+++ b/compat/memcmp.c
@@ -1,0 +1,22 @@
+#if defined (__clang__)
+
+/*
+ * Clang doesn't have the __builtin_memcmp instrinsic, instead it merely creates an alias from that
+ * name to memcmp and expects the implementation to be found in libc. Since we're compiling in
+ * freestanding mode we have no libc and thus linking fails when a few of the tutorial steps are
+ * built with clang. Therefore, we need to provide the implementation below.
+ * This code is taken from gcc 8 sources (libgcc/memcmp.c) and is in public domain
+ */
+int memcmp (const void *str1, const void *str2, unsigned int count)
+{
+	const unsigned char *s1 = str1;
+	const unsigned char *s2 = str2;
+
+	while (count-- > 0)
+	{
+		if (*s1++ != *s2++)
+			return s1[-1] < s2[-1] ? -1 : 1;
+	}
+	return 0;
+}
+#endif


### PR DESCRIPTION
First of all - thank you for the great tutorial :) Well written, a really good starting point
for anybody looking to play with bare metal programming on RPI! :)

This PR makes a handful of modifications, described below, which I think may save
time for anyone using the right Linux distribution by removing the need to build the
cross-compiler. It also fixes a small issue with clang - it has no `__builtin_memcpy` but
instead relies on libc to provide it, even in freestanding mode. 

This way it is possible to override the toolchain to use with a simple
command-line Make option. For instance, on Ubuntu it is possible to skip the
cross-compiler building step and instead install the `gcc-aarch64-linux-gnu`
package and then build all the steps as follows:

    $ make TOOLCHAIN_PREFIX=aarch64-linux-gnu

Additionally, this commit adds a simple way to use Clang (if installed on your
system):

    $ make TOOLCHAIN_PREFIX=aarch64-linux-gnu USE_CLANG=1