### PR TITLE
Bug in 10_virtualmemory

### DIFF
--- a/10_virtualmemory/mmu.c
+++ b/10_virtualmemory/mmu.c
@@ -96,7 +96,7 @@ void mmu_init()
         PT_AF |       // accessed flag
         PT_USER |     // non-privileged
         PT_ISH |      // inner shareable
-        ((r<0x80||r>data_page)? PT_RW|PT_NX : PT_RO); // different for code and data
+        ((r<0x80||r>=data_page)? PT_RW|PT_NX : PT_RO); // different for code and data
 
     // TTBR1, kernel L1
     paging[512+511]=(unsigned long)((unsigned char*)&_end+4*PAGESIZE) | // physical address


### PR DESCRIPTION
Hi,
I'm doing your tutorial, and I think I found a little bug in `mmu.c`.
By using `(r<0x80||r>data_page)`, you set the first page of the .data into RO, instead of RW.
It took me sometime to figure out what actually happened, and I fixed it now.
Thanks for the tutorial!