### PR TITLE
Fix mmu code for clang

### DIFF
--- a/10_virtualmemory/mmu.c
+++ b/10_virtualmemory/mmu.c
@@ -58,7 +58,8 @@ extern volatile unsigned char _end;
 void mmu_init()
 {
     unsigned long data_page = (unsigned long)&_data/PAGESIZE;
-    unsigned long r, b, *paging=(unsigned long*)&_end;
+    unsigned long r, b;
+    volatile unsigned long *paging=(unsigned long*)&_end;
 
     /* create MMU translation tables at _end */
 

--- a/11_exceptions/mmu.c
+++ b/11_exceptions/mmu.c
@@ -58,7 +58,8 @@ extern volatile unsigned char _end;
 void mmu_init()
 {
     unsigned long data_page = (unsigned long)&_data/PAGESIZE;
-    unsigned long r, b, *paging=(unsigned long*)&_end;
+    unsigned long r, b;
+    volatile unsigned long *paging=(unsigned long*)&_end;
 
     /* create MMU translation tables at _end */
 


### PR DESCRIPTION
Currently, the code generated by llvm/clang for mmu.c does not work due
to optimization passes. Building with -O0 works, as does setting the
'paging' variable as volatile. The latter is being done in this commit.

Tested with clang version 8.0.1 (tags/RELEASE_801/final)

11_exceptions without this fix when built with clang:

Synchronous: Unknown:
  ESR_EL1 000000001FE00000 ELR_EL1 0000000000080F50
 SPSR_EL1 00000000600003C4 FAR_EL1 0000000000000000

11_exceptions with this fix when built with clang:

Synchronous: Data abort, same EL, Translation fault at level 2:
  ESR_EL1 0000000096000006 ELR_EL1 0000000000080C60
 SPSR_EL1 00000000600003C4 FAR_EL1 FFFFFFFFFF000000

 Also updated mmu.c in 10_virtualmemory