### PR TITLE
Only write to bits 1,2 of AUX_MU_IIR_REG

### DIFF
--- a/03_uart1/uart.c
+++ b/03_uart1/uart.c
@@ -47,21 +47,21 @@ void uart_init()
     register unsigned int r;
 
     /* initialize UART */
-    *AUX_ENABLE |=1;       // enable UART1, AUX mini uart
-    *AUX_MU_CNTL = 0;
-    *AUX_MU_LCR = 3;       // 8 bits
-    *AUX_MU_MCR = 0;
-    *AUX_MU_IER = 0;
-    *AUX_MU_IIR = 0xc6;    // disable interrupts
+    *AUX_ENABLE |= 1;      // enable UART1, AUX mini uart
+    *AUX_MU_IER = 0;       // disable UART1 interrupts
+    *AUX_MU_CNTL = 0;      // disable Tx, Rx
+    *AUX_MU_IIR = 6;       // clear Tx, Rx FIFOs
+    *AUX_MU_LCR = 3;       // 8 bit mode
+    *AUX_MU_MCR = 0;       // UART1_RTS line high
     *AUX_MU_BAUD = 270;    // 115200 baud
     /* map UART1 to GPIO pins */
     r=*GPFSEL1;
-    r&=~((7<<12)|(7<<15)); // gpio14, gpio15
-    r|=(2<<12)|(2<<15);    // alt5
+    r&=~((7<<12)|(7<<15)); // gpio14, gpio15 as inputs
+    r|=(2<<12)|(2<<15);    // gpio14, gpio15 alternate function 5
     *GPFSEL1 = r;
-    *GPPUD = 0;            // enable pins 14 and 15
+    *GPPUD = 0;            // GPIO pull-up/down OFF
     r=150; while(r--) { asm volatile("nop"); }
-    *GPPUDCLK0 = (1<<14)|(1<<15);
+    *GPPUDCLK0 = (1<<14)|(1<<15); // control signal pins 14, 15
     r=150; while(r--) { asm volatile("nop"); }
     *GPPUDCLK0 = 0;        // flush GPIO setup
     *AUX_MU_CNTL = 3;      // enable Tx, Rx

--- a/04_mailboxes/uart.c
+++ b/04_mailboxes/uart.c
@@ -45,24 +45,23 @@
 void uart_init()
 {
     register unsigned int r;
-    
+
     /* initialize UART */
-    *AUX_ENABLE |=1;       // enable UART1, AUX mini uart
-    *AUX_MU_IER = 0;
-    *AUX_MU_CNTL = 0;
-    *AUX_MU_LCR = 3;       // 8 bits
-    *AUX_MU_MCR = 0;
-    *AUX_MU_IER = 0;
-    *AUX_MU_IIR = 0xc6;    // disable interrupts
+    *AUX_ENABLE |= 1;      // enable UART1, AUX mini uart
+    *AUX_MU_IER = 0;       // disable UART1 interrupts
+    *AUX_MU_CNTL = 0;      // disable Tx, Rx
+    *AUX_MU_IIR = 6;       // clear Tx, Rx FIFOs
+    *AUX_MU_LCR = 3;       // 8 bit mode
+    *AUX_MU_MCR = 0;       // UART1_RTS line high
     *AUX_MU_BAUD = 270;    // 115200 baud
     /* map UART1 to GPIO pins */
     r=*GPFSEL1;
-    r&=~((7<<12)|(7<<15)); // gpio14, gpio15
-    r|=(2<<12)|(2<<15);    // alt5
+    r&=~((7<<12)|(7<<15)); // gpio14, gpio15 as inputs
+    r|=(2<<12)|(2<<15);    // gpio14, gpio15 alternate function 5
     *GPFSEL1 = r;
-    *GPPUD = 0;            // enable pins 14 and 15
+    *GPPUD = 0;            // GPIO pull-up/down OFF
     r=150; while(r--) { asm volatile("nop"); }
-    *GPPUDCLK0 = (1<<14)|(1<<15);
+    *GPPUDCLK0 = (1<<14)|(1<<15); // control signal pins 14, 15
     r=150; while(r--) { asm volatile("nop"); }
     *GPPUDCLK0 = 0;        // flush GPIO setup
     *AUX_MU_CNTL = 3;      // enable Tx, Rx


### PR DESCRIPTION
I spotted that there was a [write of `0xc6` to `AUX_MU_IIR_REG`](https://github.com/bztsrc/raspi3-tutorial/blob/760604300b4e492093aafdbed87b605919f4c3bc/03_uart1/uart.c#L55). From the [BCM2837 ARM Peripherals](https://cs140e.sergio.bz/docs/BCM2837-ARM-Peripherals.pdf) datasheet, it looks like only bits 1 and 2 are R/W:

<img width="530" alt="Screenshot 2020-03-26 at 16 32 44" src="https://user-images.githubusercontent.com/190790/77665122-7ef90480-6f7f-11ea-9d30-7c2fb9f9a60a.png">

This PR fixes the issue by writing `0x6` instead of `0xc6`. It probably did no harm, but might have been confusing.

At the same time I added a few comments to explain the other register updates in the mini UART initialisation routine (according to my understanding, which may be flawed 😄).

Many thanks for the great tutorial!