### PR TITLE
Fix Makefile.clang and streamline with Makefile.clang of other chapters

### DIFF
--- a/01_bareminimum/Makefile.clang
+++ b/01_bareminimum/Makefile.clang
@@ -32,7 +32,7 @@ start.o: start.S
 
 kernel8.img: start.o
 	ld.lld -m aarch64elf -nostdlib start.o -T link.ld -o kernel8.elf
-	llvm-objcopy --target=aarch64-elf -O binary kernel8.elf kernel8.img
+	llvm-objcopy -O binary kernel8.elf kernel8.img
 
 clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true


### PR DESCRIPTION
The previous statement resulted in the following error:

rm kernel8.elf *.o >/dev/null 2>/dev/null || true
clang --target=aarch64-elf -Wall -O2 -ffreestanding -nostdinc -nostdlib -mcpu=cortex-a53+nosimd -c start.S -o start.o
ld.lld -m aarch64elf -nostdlib start.o -T link.ld -o kernel8.elf
llvm-objcopy --target=aarch64-elf -O binary kernel8.elf kernel8.img
llvm-objcopy: error: --target cannot be used with --input-target or --output-target
make: *** [Makefile.clang:35: kernel8.img] Error 1