### PR TITLE
Enable UART0 FIFOs

### DIFF
--- a/05_uart0/uart.c
+++ b/05_uart0/uart.c
@@ -72,8 +72,8 @@ void uart_init()
     *UART0_ICR = 0x7FF;    // clear interrupts
     *UART0_IBRD = 2;       // 115200 baud
     *UART0_FBRD = 0xB;
-    *UART0_LCRH = 0b11<<5; // 8n1
-    *UART0_CR = 0x301;     // enable Tx, Rx, FIFO
+    *UART0_LCRH = 0x7<<4;  // 8n1, enable FIFOs
+    *UART0_CR = 0x301;     // enable Tx, Rx, UART
 }
 
 /**

--- a/06_random/uart.c
+++ b/06_random/uart.c
@@ -72,8 +72,8 @@ void uart_init()
     *UART0_ICR = 0x7FF;    // clear interrupts
     *UART0_IBRD = 2;       // 115200 baud
     *UART0_FBRD = 0xB;
-    *UART0_LCRH = 0b11<<5; // 8n1
-    *UART0_CR = 0x301;     // enable Tx, Rx, FIFO
+    *UART0_LCRH = 0x7<<4;  // 8n1, enable FIFOs
+    *UART0_CR = 0x301;     // enable Tx, Rx, UART
 }
 
 /**

--- a/07_delays/uart.c
+++ b/07_delays/uart.c
@@ -73,8 +73,8 @@ void uart_init()
     *UART0_ICR = 0x7FF;    // clear interrupts
     *UART0_IBRD = 2;       // 115200 baud
     *UART0_FBRD = 0xB;
-    *UART0_LCRH = 0b11<<5; // 8n1
-    *UART0_CR = 0x301;     // enable Tx, Rx, FIFO
+    *UART0_LCRH = 0x7<<4;  // 8n1, enable FIFOs
+    *UART0_CR = 0x301;     // enable Tx, Rx, UART
 }
 
 /**

--- a/08_power/uart.c
+++ b/08_power/uart.c
@@ -73,8 +73,8 @@ void uart_init()
     *UART0_ICR = 0x7FF;    // clear interrupts
     *UART0_IBRD = 2;       // 115200 baud
     *UART0_FBRD = 0xB;
-    *UART0_LCRH = 0b11<<5; // 8n1
-    *UART0_CR = 0x301;     // enable Tx, Rx, FIFO
+    *UART0_LCRH = 0x7<<4;  // 8n1, enable FIFOs
+    *UART0_CR = 0x301;     // enable Tx, Rx, UART
 }
 
 /**

--- a/09_framebuffer/uart.c
+++ b/09_framebuffer/uart.c
@@ -73,8 +73,8 @@ void uart_init()
     *UART0_ICR = 0x7FF;    // clear interrupts
     *UART0_IBRD = 2;       // 115200 baud
     *UART0_FBRD = 0xB;
-    *UART0_LCRH = 0b11<<5; // 8n1
-    *UART0_CR = 0x301;     // enable Tx, Rx, FIFO
+    *UART0_LCRH = 0x7<<4;  // 8n1, enable FIFOs
+    *UART0_CR = 0x301;     // enable Tx, Rx, UART
 }
 
 /**

--- a/10_virtualmemory/uart.c
+++ b/10_virtualmemory/uart.c
@@ -72,8 +72,8 @@ void uart_init()
     *UART0_ICR = 0x7FF;    // clear interrupts
     *UART0_IBRD = 2;       // 115200 baud
     *UART0_FBRD = 0xB;
-    *UART0_LCRH = 0b11<<5; // 8n1
-    *UART0_CR = 0x301;     // enable Tx, Rx, FIFO
+    *UART0_LCRH = 0x7<<4;  // 8n1, enable FIFOs
+    *UART0_CR = 0x301;     // enable Tx, Rx, UART
 }
 
 /**

--- a/11_exceptions/uart.c
+++ b/11_exceptions/uart.c
@@ -72,8 +72,8 @@ void uart_init()
     *UART0_ICR = 0x7FF;    // clear interrupts
     *UART0_IBRD = 2;       // 115200 baud
     *UART0_FBRD = 0xB;
-    *UART0_LCRH = 0b11<<5; // 8n1
-    *UART0_CR = 0x301;     // enable Tx, Rx, FIFO
+    *UART0_LCRH = 0x7<<4;  // 8n1, enable FIFOs
+    *UART0_CR = 0x301;     // enable Tx, Rx, UART
 }
 
 /**

--- a/12_printf/uart.c
+++ b/12_printf/uart.c
@@ -76,8 +76,8 @@ void uart_init()
     *UART0_ICR = 0x7FF;    // clear interrupts
     *UART0_IBRD = 2;       // 115200 baud
     *UART0_FBRD = 0xB;
-    *UART0_LCRH = 0b11<<5; // 8n1
-    *UART0_CR = 0x301;     // enable Tx, Rx, FIFO
+    *UART0_LCRH = 0x7<<4;  // 8n1, enable FIFOs
+    *UART0_CR = 0x301;     // enable Tx, Rx, UART
 }
 
 /**

--- a/13_debugger/uart.c
+++ b/13_debugger/uart.c
@@ -76,8 +76,8 @@ void uart_init()
     *UART0_ICR = 0x7FF;    // clear interrupts
     *UART0_IBRD = 2;       // 115200 baud
     *UART0_FBRD = 0xB;
-    *UART0_LCRH = 0b11<<5; // 8n1
-    *UART0_CR = 0x301;     // enable Tx, Rx, FIFO
+    *UART0_LCRH = 0x7<<4;  // 8n1, enable FIFOs
+    *UART0_CR = 0x301;     // enable Tx, Rx, UART
 }
 
 /**

--- a/14_raspbootin64/uart.c
+++ b/14_raspbootin64/uart.c
@@ -72,8 +72,8 @@ void uart_init()
     *UART0_ICR = 0x7FF;    // clear interrupts
     *UART0_IBRD = 2;       // 115200 baud
     *UART0_FBRD = 0xB;
-    *UART0_LCRH = 0b11<<5; // 8n1
-    *UART0_CR = 0x301;     // enable Tx, Rx, FIFO
+    *UART0_LCRH = 0x7<<4;  // 8n1, enable FIFOs
+    *UART0_CR = 0x301;     // enable Tx, Rx, UART
 }
 
 /**

--- a/15_writesector/uart.c
+++ b/15_writesector/uart.c
@@ -73,8 +73,8 @@ void uart_init()
     *UART0_ICR = 0x7FF;    // clear interrupts
     *UART0_IBRD = 2;       // 115200 baud
     *UART0_FBRD = 0xB;
-    *UART0_LCRH = 0b11<<5; // 8n1
-    *UART0_CR = 0x301;     // enable Tx, Rx, FIFO
+    *UART0_LCRH = 0x7<<4;  // 8n1, enable FIFOs
+    *UART0_CR = 0x301;     // enable Tx, Rx, UART
 }
 
 /**


### PR DESCRIPTION
According to [BCM2835 ARM Peripherals](https://datasheets.raspberrypi.org/bcm2835/bcm2835-peripherals.pdf), the option for enabling FIFO is
on the 4th bit of `UART0_LCRH`.

Without enabling FIFO, we may encounter [losing part of key sequences](https://www.raspberrypi.org/forums/viewtopic.php?f=72&t=315126).

In this commit, I adjust all `uart_init()` functions that use UART0 and
enable FIFO feature.