### PR TITLE
Change QEMU Raspberry Pi machine name in command line from raspi3 to raspi3b

### DIFF
--- a/01_bareminimum/Makefile.clang
+++ b/01_bareminimum/Makefile.clang
@@ -38,4 +38,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -d in_asm
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -d in_asm

--- a/01_bareminimum/Makefile.gcc
+++ b/01_bareminimum/Makefile.gcc
@@ -38,4 +38,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -d in_asm
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -d in_asm

--- a/01_bareminimum/OLVASSEL.md
+++ b/01_bareminimum/OLVASSEL.md
@@ -6,7 +6,7 @@ be kell tudnia bootolni a Raspberry Pi-n, ahol végtelen ciklusban várakoztatja
 következő paranccsal:
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -kernel kernel8.img -d in_asm
+$ qemu-system-aarch64 -M raspi3b -kernel kernel8.img -d in_asm
         ... kimenet törölve az átláthatóság miatt, utolsó sor: ...
 0x0000000000080004:  17ffffff      b #-0x4 (addr 0x80000)
 ```

--- a/01_bareminimum/README.md
+++ b/01_bareminimum/README.md
@@ -5,7 +5,7 @@ Okay, we're not going to do anything here, just test our toolchain. The resultin
 boot on Raspberry Pi, and stop the CPU cores in an infinite loop. You can check that by running
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -kernel kernel8.img -d in_asm
+$ qemu-system-aarch64 -M raspi3b -kernel kernel8.img -d in_asm
         ... output removed for clearity, last line: ...
 0x0000000000080004:  17ffffff      b #-0x4 (addr 0x80000)
 ```

--- a/02_multicorec/Makefile.clang
+++ b/02_multicorec/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -d in_asm
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -d in_asm

--- a/02_multicorec/Makefile.gcc
+++ b/02_multicorec/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -d in_asm
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -d in_asm

--- a/03_uart1/Makefile.clang
+++ b/03_uart1/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial null -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial null -serial stdio

--- a/03_uart1/Makefile.gcc
+++ b/03_uart1/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial null -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial null -serial stdio

--- a/04_mailboxes/Makefile.clang
+++ b/04_mailboxes/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial null -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial null -serial stdio

--- a/04_mailboxes/Makefile.gcc
+++ b/04_mailboxes/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial null -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial null -serial stdio

--- a/05_uart0/Makefile.clang
+++ b/05_uart0/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/05_uart0/Makefile.gcc
+++ b/05_uart0/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/05_uart0/OLVASSEL.md
+++ b/05_uart0/OLVASSEL.md
@@ -5,7 +5,7 @@ Ebben az okatatóanyagban ugyanazt csináljuk, mint a 4-esben, de most a széria
 Emiatt ez a példa könnyen használható qemu-val is:
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+$ qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio
 My serial number is: 0000000000000000
 ```
 

--- a/05_uart0/README.md
+++ b/05_uart0/README.md
@@ -5,7 +5,7 @@ This tutorial does the same as tutorial 04, but it prints the serial number on U
 easily with qemu, like
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+$ qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio
 My serial number is: 0000000000000000
 ```
 

--- a/06_random/Makefile.clang
+++ b/06_random/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/06_random/Makefile.gcc
+++ b/06_random/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/07_delays/Makefile.clang
+++ b/07_delays/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/07_delays/Makefile.gcc
+++ b/07_delays/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/08_power/Makefile.clang
+++ b/08_power/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/08_power/Makefile.gcc
+++ b/08_power/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/09_framebuffer/Makefile.clang
+++ b/09_framebuffer/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/09_framebuffer/Makefile.gcc
+++ b/09_framebuffer/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/0A_pcscreenfont/Makefile.clang
+++ b/0A_pcscreenfont/Makefile.clang
@@ -49,4 +49,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/0A_pcscreenfont/Makefile.gcc
+++ b/0A_pcscreenfont/Makefile.gcc
@@ -49,4 +49,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/0B_readsector/Makefile.clang
+++ b/0B_readsector/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio

--- a/0B_readsector/Makefile.gcc
+++ b/0B_readsector/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio

--- a/0C_directory/Makefile.clang
+++ b/0C_directory/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio

--- a/0C_directory/Makefile.gcc
+++ b/0C_directory/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio

--- a/0C_directory/OLVASSEL.md
+++ b/0C_directory/OLVASSEL.md
@@ -5,7 +5,7 @@ Most hogy már tudunk szektort beolvasni, ideje értelmezni a fájlrendszert. Ez
 hogy hogyan listázzuk ki egy FAT16 vagy FAT32 partíció gyökérkönyvtárát.
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -drive file=test.dd,if=sd,format=raw -serial stdio
+$ qemu-system-aarch64 -M raspi3b -drive file=test.dd,if=sd,format=raw -serial stdio
         ... kimenet törölve az átláthatóság miatt ...
 MBR disk identifier: 12345678
 FAT partition starts at: 00000008

--- a/0C_directory/README.md
+++ b/0C_directory/README.md
@@ -5,7 +5,7 @@ Now that we can load a sector from the storage, it is time to parse it as a file
 tutorial will show you how to list the root directory entries of a FAT16 or FAT32 partition.
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -drive file=test.dd,if=sd,format=raw -serial stdio
+$ qemu-system-aarch64 -M raspi3b -drive file=test.dd,if=sd,format=raw -serial stdio
         ... output removed for clearity ...
 MBR disk identifier: 12345678
 FAT partition starts at: 00000008

--- a/0D_readfile/Makefile.clang
+++ b/0D_readfile/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio

--- a/0D_readfile/Makefile.gcc
+++ b/0D_readfile/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio

--- a/0D_readfile/OLVASSEL.md
+++ b/0D_readfile/OLVASSEL.md
@@ -5,7 +5,7 @@ Megtanultuk, hogy kell beolvasni és értelmezni a gyökérkönyvtárat. Ebben a
 a gyökérkönyvtárból, és a kluszterláncát végigjárva teljes egészében betöltjük a memóriába.
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -drive file=test.dd,if=sd,format=raw -serial stdio
+$ qemu-system-aarch64 -M raspi3b -drive file=test.dd,if=sd,format=raw -serial stdio
         ... kimenet törölve az átláthatóság miatt ...
 FAT File LICENC~1BRO starts at cluster: 00000192
 FAT Bytes per Sector: 00000200

--- a/0D_readfile/README.md
+++ b/0D_readfile/README.md
@@ -5,7 +5,7 @@ We learned how to read and parse the root directory. In this tutorial we'll get 
 root directory, and walk through the cluster chain to load it entirely into memory.
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -drive file=test.dd,if=sd,format=raw -serial stdio
+$ qemu-system-aarch64 -M raspi3b -drive file=test.dd,if=sd,format=raw -serial stdio
         ... output removed for clearity ...
 FAT File LICENC~1BRO starts at cluster: 00000192
 FAT Bytes per Sector: 00000200

--- a/0E_initrd/Makefile.clang
+++ b/0E_initrd/Makefile.clang
@@ -52,4 +52,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/0E_initrd/Makefile.gcc
+++ b/0E_initrd/Makefile.gcc
@@ -52,4 +52,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/0F_executionlevel/Makefile.clang
+++ b/0F_executionlevel/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/0F_executionlevel/Makefile.gcc
+++ b/0F_executionlevel/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/0F_executionlevel/OLVASSEL.md
+++ b/0F_executionlevel/OLVASSEL.md
@@ -8,7 +8,7 @@ indulhat egyből EL1-en, az igazi Raspberry Pi vason azonban általában virtual
 ébredünk. Qemu alatt a szintváltást a "-d int" kapcsolóval debuggolhatjuk.
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio -d int
+$ qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio -d int
 Exception return from AArch64 EL2 to AArch64 EL1 PC 0x8004c
 Current EL is: 00000001
 ```

--- a/0F_executionlevel/README.md
+++ b/0F_executionlevel/README.md
@@ -7,7 +7,7 @@ make sure of it, we are at supervisor level, EL1. Qemu may start machine at EL1,
 normally boots at hypervisor level, EL2. Under qemu use "-d int" to debug the level change.
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio -d int
+$ qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio -d int
 Exception return from AArch64 EL2 to AArch64 EL1 PC 0x8004c
 Current EL is: 00000001
 ```

--- a/10_virtualmemory/Makefile.clang
+++ b/10_virtualmemory/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/10_virtualmemory/Makefile.gcc
+++ b/10_virtualmemory/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/11_exceptions/Makefile.clang
+++ b/11_exceptions/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/11_exceptions/Makefile.gcc
+++ b/11_exceptions/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/11_exceptions/OLVASSEL.md
+++ b/11_exceptions/OLVASSEL.md
@@ -6,7 +6,7 @@ Nem könnyű vakon létrehozni ezt a táblát, ezért kivételkezelőket fogunk 
 a fontos rendszer regisztereket, hogy azonosíthassuk és megtalálhassuk a problémát a címfordítási táblánkban.
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+$ qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio
 Synchronous: Data abort, same EL, Translation fault at level 2:
   ESR_EL1 0000000096000006 ELR_EL1 0000000000080D7C
  SPSR_EL1 00000000200003C4 FAR_EL1 FFFFFFFFFF000000

--- a/11_exceptions/README.md
+++ b/11_exceptions/README.md
@@ -6,7 +6,7 @@ easy to write the table blindly, so we're going to add exception handlers this t
 system registers to identify the problem with our translation tables.
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+$ qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio
 Synchronous: Data abort, same EL, Translation fault at level 2:
   ESR_EL1 0000000096000006 ELR_EL1 0000000000080D7C
  SPSR_EL1 00000000200003C4 FAR_EL1 FFFFFFFFFF000000

--- a/12_printf/Makefile.clang
+++ b/12_printf/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/12_printf/Makefile.gcc
+++ b/12_printf/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/12_printf/OLVASSEL.md
+++ b/12_printf/OLVASSEL.md
@@ -5,7 +5,7 @@ Mielőtt kibővítenénk a kivételkezelőnket, szükségünk lesz néhány jól
 programozunk, nem támaszkodhatunk a libc-re, ezért nekünk kell egy saját printf() implementációt megvalósítanunk.
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+$ qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio
 Hello World!
 This is character 'A', a hex number: 7FFF and in decimal: 32767
 Padding test: '00007FFF', '    -123'

--- a/12_printf/README.md
+++ b/12_printf/README.md
@@ -5,7 +5,7 @@ Before we can improve our exception handler, we are going to need some functions
 Since we are programming bare metal, we don't have libc, therefore we have to implement printf() on our own.
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+$ qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio
 Hello World!
 This is character 'A', a hex number: 7FFF and in decimal: 32767
 Padding test: '00007FFF', '    -123'

--- a/13_debugger/Makefile.clang
+++ b/13_debugger/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/13_debugger/Makefile.gcc
+++ b/13_debugger/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/13_debugger/OLVASSEL.md
+++ b/13_debugger/OLVASSEL.md
@@ -5,7 +5,7 @@ Zuzassunk egy nagyot, rakjunk mindjárt egy interaktív debuggert a kivételkeze
 nem lesz olyan vészes. (Egy kompletebb, többplatformos függvénykönyvtárért, lásd a [mini debugger](https://gitlab.com/bztsrc/minidbg)-t.)
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+$ qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio
 Synchronous: Breakpoint instruction
 > x
 0007FFF0: 13 60 09 00  00 00 00 00  24 10 20 3F  00 00 00 00  .`......$. ?....

--- a/13_debugger/README.md
+++ b/13_debugger/README.md
@@ -5,7 +5,7 @@ Let's rock by implementing an interactive debugger in our exception handler! :-)
 shouldn't be hard. (For a more roboust multiplatform library, see [mini debugger](https://gitlab.com/bztsrc/minidbg).)
 
 ```sh
-$ qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+$ qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio
 Synchronous: Breakpoint instruction
 > x
 0007FFF0: 13 60 09 00  00 00 00 00  24 10 20 3F  00 00 00 00  .`......$. ?....

--- a/14_raspbootin64/Makefile.clang
+++ b/14_raspbootin64/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/14_raspbootin64/Makefile.gcc
+++ b/14_raspbootin64/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio

--- a/15_writesector/Makefile.clang
+++ b/15_writesector/Makefile.clang
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio

--- a/15_writesector/Makefile.gcc
+++ b/15_writesector/Makefile.gcc
@@ -43,4 +43,4 @@ clean:
 	rm kernel8.elf *.o >/dev/null 2>/dev/null || true
 
 run:
-	qemu-system-aarch64 -M raspi3 -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio
+	qemu-system-aarch64 -M raspi3b -kernel kernel8.img -drive file=test.dd,if=sd,format=raw -serial stdio

--- a/OLVASSEL.md
+++ b/OLVASSEL.md
@@ -101,16 +101,16 @@ a támogatást hozzá, így hamarosan érkezik (FRISSÍTÉS: elérhető a [qemu 
 sajnos fordítani kell a qemu-t a legfrissebb forrásból. Miután lefordult, így tudod használni:
 
 ```sh
-qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio
 ```
 
 Vagy (a fájl rendszer oktatóanyagok esetében)
 
 ```sh
-qemu-system-aarch64 -M raspi3 -kernel kernel8.img -drive file=$(yourimagefile),if=sd,format=raw -serial stdio
+qemu-system-aarch64 -M raspi3b -kernel kernel8.img -drive file=$(yourimagefile),if=sd,format=raw -serial stdio
 ```
 
-**-M raspi3**
+**-M raspi3b**
 Az első paraméter utasítja a qemu-t a Raspberry Pi 3 hardver emulálására.
 
 **-kernel kernel8.img**

--- a/README.md
+++ b/README.md
@@ -103,17 +103,17 @@ it's coming soon (UPDATE: available in [qemu 2.12](https://wiki.qemu.org/ChangeL
 compile qemu from the latest source. Once compiled, you can use it with:
 
 ```sh
-qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio
+qemu-system-aarch64 -M raspi3b -kernel kernel8.img -serial stdio
 ```
 
 Or (with the file system tutorials)
 
 ```sh
-qemu-system-aarch64 -M raspi3 -kernel kernel8.img -drive file=$(yourimagefile),if=sd,format=raw -serial stdio
+qemu-system-aarch64 -M raspi3b -kernel kernel8.img -drive file=$(yourimagefile),if=sd,format=raw -serial stdio
 ```
 
-**-M raspi3**
-The first argument tells qemu to emulate Raspberry Pi 3 hardware.
+**-M raspi3b**
+The first argument tells qemu to emulate Raspberry Pi 3 Model B hardware.
 
 **-kernel kernel8.img**
 The second tells the kernel filename to be used.


### PR DESCRIPTION
According to [QEMU deprecated features list](https://qemu.readthedocs.io/en/stable-6.1/about/deprecated.html#raspberry-pi-raspi2-and-raspi3-machines-since-5-2), the name `raspi3` has been deprecated in QEMU 5.2 and the machine name `raspi3b` should be used instead.