### PR TITLE
Fix QEMU FrameBuffer Segmentation fault

### DIFF
--- a/09_framebuffer/main.c
+++ b/09_framebuffer/main.c
@@ -25,9 +25,12 @@
 
 #include "uart.h"
 #include "lfb.h"
+#include "delays.h"
 
 void main()
 {
+    wait_msec(100000);
+
     // set up serial console and linear frame buffer
     uart_init();
     lfb_init();

--- a/0A_pcscreenfont/main.c
+++ b/0A_pcscreenfont/main.c
@@ -25,9 +25,12 @@
 
 #include "uart.h"
 #include "lfb.h"
+#include "delays.h"
 
 void main()
 {
+    wait_msec(100000);
+
     // set up serial console and linear frame buffer
     uart_init();
     lfb_init();


### PR DESCRIPTION
Actually, I don't know exactly what's happened, but the delay works.
When I debug with GDB, the fault disappears, so i guess it should be waiting for some initialization to complete.