### PR TITLE
Update README with fix for qemu -serial stdio bug ***FIX***

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Finally the last argument redirects the emulated UART0 to the standard input/out
 sent to the serial line will be displayed, and every key typed in the terminal will be received by the vm. Only works with the
 tutorials 05 and above, as UART1 is *not* redirected by default. For that, you would have to add something like
 `-chardev socket,host=localhost,port=1111,id=aux -serial chardev:aux` (thanks [@godmar](https://github.com/godmar) for the info),
-or simply use two `-serial` arguments (thanks [@cirosantilli](https://github.com/cirosantilli)).
+or simply use two `-serial` arguments (thanks [@cirosantilli](https://github.com/cirosantilli)). If you an encounter a qemu error stating `qemu-system-aarch64: -serial stdio: could not connect serial device to character backend 'stdio'` the simple fix is to change `-serial stdio` to `-serial mon:stdio`.
 
 **!!!WARNING!!!** Qemu emulation is rudimentary, only the most common peripherals are emulated! **!!!WARNING!!!**
 


### PR DESCRIPTION
Pull request contains a small modification to the README to make note of an issue I encountered that took me awhile to find a solution.

I saw that some other people were having this issue although I did not see a solution so I thought this would be a nice addition to the README since I found a fix. I had this problem on an M1 Pro MacBook Pro running QEMU version 9.0.1. When trying to run `make run` with the command `qemu-system-aarch64 -nographic -M raspi3b -kernel kernel8.img -serial null -serial stdio` the error `qemu-system-aarch64: -serial stdio: could not connect serial device to character backend 'stdio'` was thrown. After looking on the Qemu wiki I found the fix to be adding mon: before stdio such that the option becomes `-serial mon:stdio`. 